### PR TITLE
Fix relayMessages / relayOldMessages type (should be a string).

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,8 +34,8 @@ cat <<EOF > /opt/xmr/config.json
   "queueSize": ${XMR_QUEUE_SIZE:-10},
   "debug": ${XMR_DEBUG:-false},
   "ipv6PubSupport": ${XMR_IPV6PUBSUPPORT:-false},
-  "relayOldMessages": ${XMR_RELAY_OLD_MESSAGES:-false},
-  "relayMessages": ${XMR_RELAY_MESSAGES:-false}
+  "relayOldMessages": "${XMR_RELAY_OLD_MESSAGES:-false}",
+  "relayMessages": "${XMR_RELAY_MESSAGES:-false}"
 }
 EOF
 

--- a/src/Controller/Relay.php
+++ b/src/Controller/Relay.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (C) 2025 Xibo Signage Ltd
+ * Copyright (C) 2026 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - https://xibosignage.com
  *
@@ -55,7 +55,7 @@ class Relay
             $this->socket = (new \ZMQContext())->getSocket(\ZMQ::SOCKET_REQ);
             $this->socket->setSockOpt(\ZMQ::SOCKOPT_LINGER, 2000);
             $this->socket->connect($this->relayOldMessages);
-        } catch (\Exception $exception) {
+        } catch (\Throwable $exception) {
             $this->socket = null;
             $this->relayOldMessages = null;
 
@@ -70,7 +70,7 @@ class Relay
         if ($this->socket !== null) {
             try {
                 $this->socket->disconnect($this->relayOldMessages);
-            } catch (\Exception $exception) {
+            } catch (\Throwable $exception) {
                 $this->socket = null;
                 $this->relayOldMessages = null;
 


### PR DESCRIPTION
Better error capture configuring ZMQ.

Fixes #57